### PR TITLE
Add system dependencies for wechat-moments

### DIFF
--- a/wechat-moments.rb
+++ b/wechat-moments.rb
@@ -8,6 +8,8 @@ class WechatMoments < Formula
 
   depends_on "python@3.12"
   depends_on "pipx"
+  depends_on "android-platform-tools" # adb
+  depends_on "tesseract"              # for pytesseract OCR
 
   def install
     system "pipx", "install", "wechat-moments==#{version}",


### PR DESCRIPTION
## Summary

- Add `android-platform-tools` dependency (provides `adb` for device communication)
- Add `tesseract` dependency (required by `pytesseract` for OCR functionality)

These system dependencies are required for `wechat-moments` to function properly.

Made with [Cursor](https://cursor.com)