### PR TITLE
Fix android-platform-tools dependency (now a cask)

### DIFF
--- a/wechat-moments.rb
+++ b/wechat-moments.rb
@@ -8,8 +8,15 @@ class WechatMoments < Formula
 
   depends_on "python@3.12"
   depends_on "pipx"
-  depends_on "android-platform-tools" # adb
-  depends_on "tesseract"              # for pytesseract OCR
+  depends_on "tesseract" # for pytesseract OCR
+
+  def caveats
+    <<~EOS
+      This formula requires Android Platform Tools (adb).
+      Install it with:
+        brew install --cask android-platform-tools
+    EOS
+  end
 
   def install
     system "pipx", "install", "wechat-moments==#{version}",


### PR DESCRIPTION
## Summary

`android-platform-tools` has been migrated to a cask in Homebrew, so declaring it as a formula dependency causes `brew install wechat-moments` to fail.

## Changes

- Remove `depends_on "android-platform-tools"` 
- Add `caveats` block to prompt users to install the cask manually after installation

Users will now see this message after installing:

```
This formula requires Android Platform Tools (adb).
Install it with:
  brew install --cask android-platform-tools
```

Made with [Cursor](https://cursor.com)